### PR TITLE
Clean the build directory when rebuilding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,7 +1078,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "detect-indent": {
@@ -3145,7 +3145,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "jsonfile": {
@@ -3645,9 +3645,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Tests? We don't need no stinking tests\" && exit 1",
-    "build": "babel src --out-dir build --source-maps",
+    "clean": "rimraf build",
+    "build": "npm run clean && babel src --out-dir build --source-maps",
     "start": "npm run build && node build/index.js",
     "prepare": "npm run build"
   },
@@ -27,6 +28,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.5.2",
+    "rimraf": "^2.6.2",
     "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
Ensure that the `build` directory is removed prior to rebuilding the source, so any leftover files from a previous build are cleaned up.

Fixes #9.