### PR TITLE
Permute the filesystem and measure watcher accuracy and latency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3679,6 +3679,11 @@
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
       "dev": true
     },
+    "seedrandom": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw="
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "fs-extra": "^4.0.2",
     "human-format": "^0.8.0",
     "nsfw": "^1.0.15",
+    "seedrandom": "^2.4.3",
     "temp": "^0.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Tests? We don't need no stinking tests\" && exit 1",
-    "build": "babel src --out-dir build --source-maps",
+    "build": "babel src --out-dir build --source-maps --copy-files",
     "start": "npm run build && node build/index.js",
     "prepare": "npm run build"
   },

--- a/src/default-churn-profile.json
+++ b/src/default-churn-profile.json
@@ -1,0 +1,9 @@
+{
+  "fileCreation": { "proportion": 50 },
+  "fileModification": { "proportion": 70 },
+  "fileDeletion": { "proportion": 50 },
+  "fileRename": { "proportion": 10},
+  "directoryCreation": { "proportion": 20 },
+  "directoryDeletion": { "proportion": 20 },
+  "directoryRename": { "proportion": 10 }
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -57,10 +57,7 @@ function humanSeconds (seconds) {
 const timeScaleMs = new humanFormat.Scale({
   milliseconds: 1,
   seconds: 1000,
-  minutes: 60,
-  hours: 3600,
-  days: 86400,
-  months: 2592000
+  minutes: 60000
 })
 
 function humanMilliseconds (milliseconds) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,6 +63,19 @@ function atRandom (array) {
   return array[ind]
 }
 
+function chooseProportionally (choices) {
+  const total = choices.reduce((sum, choice) => sum + choice[0], 0)
+  const chosen = Math.floor(Math.random() * total)
+
+  let accumulated = 0
+  for (const [proportion, choice] of choices) {
+    accumulated += proportion
+    if (accumulated > chosen) return choice
+  }
+
+  throw new Error(`Invalid choice ${chosen} from total ${total}`)
+}
+
 function reportError (error) {
   console.error('>> ERROR <<'.dangerBanner)
   let msg = 'No further information provided.'
@@ -114,6 +127,7 @@ module.exports = {
   humanSeconds,
   humanBytes,
   atRandom,
+  chooseProportionally,
   reportError,
   setResourceLogFile,
   reportUsage

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,7 +42,7 @@ function actionName (action) {
   return actionNames.get(action) || `unknown: ${action}`
 }
 
-const timeScale = new humanFormat.Scale({
+const timeScaleS = new humanFormat.Scale({
   seconds: 1,
   minutes: 60,
   hours: 3600,
@@ -51,7 +51,20 @@ const timeScale = new humanFormat.Scale({
 })
 
 function humanSeconds (seconds) {
-  return humanFormat(seconds, {scale: timeScale}) + ` (${seconds}s)`.sidenote
+  return humanFormat(seconds, {scale: timeScaleS}) + ` (${seconds}s)`.sidenote
+}
+
+const timeScaleMs = new humanFormat.Scale({
+  milliseconds: 1,
+  seconds: 1000,
+  minutes: 60,
+  hours: 3600,
+  days: 86400,
+  months: 2592000
+})
+
+function humanMilliseconds (milliseconds) {
+  return humanFormat(milliseconds, {scale: timeScaleMs}) + ` (${milliseconds}ms)`.sidenote
 }
 
 function humanBytes (bytes) {
@@ -125,6 +138,7 @@ module.exports = {
   tempDir,
   actionName,
   humanSeconds,
+  humanMilliseconds,
   humanBytes,
   atRandom,
   chooseProportionally,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -26,7 +26,7 @@ function tempDir (prefix) {
         return
       }
 
-      resolve(dirPath)
+      resolve(fs.realpath(dirPath))
     })
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const program = require('commander')
 const colors = require('colors')
+const seedrandom = require('seedrandom')
 
 const cli = require('./cli')
 const {createFacade, available} = require('./facade')
@@ -24,6 +25,7 @@ const watcherRx = new RegExp('^(' + available().join('|') + ')$', 'i')
 program
   .version(require('../package.json').version)
   .option('--use <impl>', `use specified watcher implementation (${watcherNames})`, watcherRx)
+  .option('--seed <seed>', 'seed the PRNG for predictable output')
   .option('--logging-dir <path>', '(watcher only) produce diagnostic logging to files within a directory')
   .option('--log-main-stdout', '(watcher only) log main thread activity directly to stdout')
   .option('--log-worker-stdout', '(watcher only) log worker thread activity directly to stdout')
@@ -65,6 +67,15 @@ if (program.gen === true) {
 
   program.gen = program.root
 }
+
+const decodedSeed = program.seed
+  ? Buffer.from(program.seed, 'base64').toString('utf8')
+  : null
+
+const seed = seedrandom(decodedSeed, {global: true})
+
+const encodedSeed = Buffer.from(seed, 'utf8').toString('base64')
+console.log(`--seed ${encodedSeed}\n\n`.dim)
 
 async function main () {
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -105,13 +105,15 @@ async function main () {
       await serialWatchers(facade, {
         root: program.root,
         poll: program.poll,
-        count: program.watcherCount || 1000
+        count: program.watcherCount || 1000,
+        loggingDir: program.loggingDir
       })
     } else if (program.exercise === 'parallel') {
       await parallelWatchers(facade, {
         root: program.root,
         poll: program.poll,
-        count: program.watcherCount || 1000
+        count: program.watcherCount || 1000,
+        loggingDir: program.loggingDir
       })
     }
 

--- a/src/parallel-watchers.js
+++ b/src/parallel-watchers.js
@@ -62,7 +62,7 @@ module.exports = async function (facade, opts) {
   // Synthesize some filesystem events
   console.log(`\n>> CREATING FILESYSTEM EVENTS <<`.banner)
 
-  const report = new Report()
+  const report = new Report({loggingDir: opts.loggingDir})
   await Promise.all(
     trees.map(tree => queue.enqueue(() => churn({
       tree,

--- a/src/parallel-watchers.js
+++ b/src/parallel-watchers.js
@@ -3,8 +3,6 @@ const {reportUsage, reportError} = require('./helpers')
 const {PromiseQueue} = require('./queue')
 const {createTree, churn, Report} = require('./random-fs')
 
-const defaultChurnProfile = require('./default-churn-profile')
-
 module.exports = async function (facade, opts) {
   console.log('>> PARALLEL WATCHER STRESS TEST <<'.banner)
 
@@ -67,8 +65,8 @@ module.exports = async function (facade, opts) {
     trees.map(tree => queue.enqueue(() => churn({
       tree,
       subscribe: cb => { callbacksByTree.set(tree, cb) },
-      iterations: 1000,
-      profile: defaultChurnProfile,
+      iterations: opts.churnCount,
+      profile: opts.churnProfile,
       report
     })))
   )

--- a/src/parallel-watchers.js
+++ b/src/parallel-watchers.js
@@ -68,7 +68,6 @@ module.exports = async function (facade, opts) {
       tree,
       subscribe: cb => { callbacksByTree.set(tree, cb) },
       iterations: 1000,
-      parallel: 1,
       profile: defaultChurnProfile,
       report
     })))

--- a/src/parallel-watchers.js
+++ b/src/parallel-watchers.js
@@ -17,6 +17,11 @@ module.exports = async function (facade, opts) {
     return path.join(opts.root, `root-${i}`)
   }
 
+  function logNumber (i) {
+    if (!opts.loggingDir) return null
+    return path.join(opts.loggingDir, `change-${i}.log`)
+  }
+
   for (let i = 0; i < opts.count; i++) {
     const tree = await createTree({
       root: rootNumber(i),
@@ -62,12 +67,13 @@ module.exports = async function (facade, opts) {
 
   const report = new Report({loggingDir: opts.loggingDir})
   await Promise.all(
-    trees.map(tree => queue.enqueue(() => churn({
+    trees.map((tree, i) => queue.enqueue(() => churn({
       tree,
       subscribe: cb => { callbacksByTree.set(tree, cb) },
       iterations: opts.churnCount,
       profile: opts.churnProfile,
-      report
+      report,
+      logPath: logNumber(i)
     })))
   )
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,0 +1,53 @@
+class PromiseQueue {
+  constructor (parallelism) {
+    this.parallelism = parallelism
+
+    this.waiting = []
+    this.running = new Set()
+    this.becameEmpty = () => {}
+  }
+
+  enqueue (asyncFn) {
+    return new Promise((resolve, reject) => {
+      this.waiting.push({asyncFn, resolve, reject})
+      this.next()
+    })
+  }
+
+  next () {
+    if (this.running.size >= this.parallelism) return
+    if (this.waiting.length === 0) {
+      this.becameEmpty()
+      return
+    }
+
+    const {asyncFn, resolve, reject} = this.waiting.shift()
+    const promise = asyncFn()
+    this.running.add(promise)
+
+    promise.then(
+      () => {
+        this.running.delete(promise)
+        resolve()
+        this.next()
+      },
+      err => {
+        this.running.delete(promise)
+        reject(err)
+        this.next()
+      }
+    )
+  }
+
+  waitingCount () {
+    return this.waiting.length
+  }
+
+  whenEmpty () {
+    return new Promise(resolve => {
+      this.becameEmpty = resolve
+    })
+  }
+}
+
+module.exports = {PromiseQueue}

--- a/src/queue.js
+++ b/src/queue.js
@@ -15,9 +15,12 @@ class PromiseQueue {
   }
 
   next () {
-    if (this.running.size >= this.parallelism) return
     if (this.waiting.length === 0) {
       this.becameEmpty()
+      return
+    }
+
+    if (this.running.size >= this.parallelism) {
       return
     }
 
@@ -44,6 +47,10 @@ class PromiseQueue {
   }
 
   whenEmpty () {
+    if (this.waiting.length === 0) {
+      return Promise.resolve()
+    }
+
     return new Promise(resolve => {
       this.becameEmpty = resolve
     })

--- a/src/random-fs/changes.js
+++ b/src/random-fs/changes.js
@@ -1,0 +1,107 @@
+const fs = require('fs-extra')
+
+const {SingleEventMatcher, RenameEventMatcher} = require('./matcher')
+
+class Change {
+  constructor (tree) {
+    this.tree = tree
+  }
+}
+
+class FileCreationChange extends Change {
+  async enact () {
+    const filePath = await this.tree.createNewFile()
+    return new SingleEventMatcher({
+      action: 'created',
+      kind: 'file',
+      path: filePath
+    })
+  }
+}
+
+class FileModificationChange extends Change {
+  async enact () {
+    const filePath = this.tree.randomFile()
+    await fs.appendFile('appended a line\n', filePath)
+    return new SingleEventMatcher({
+      action: 'modified',
+      kind: 'file',
+      path: filePath
+    })
+  }
+}
+
+class FileDeletionChange extends Change {
+  async enact () {
+    const filePath = this.tree.randomFile()
+    this.tree.fileWasDeleted(filePath)
+    await fs.unlink(filePath)
+    return new SingleEventMatcher({
+      action: 'deleted',
+      kind: 'file',
+      path: filePath
+    })
+  }
+}
+
+class FileRenameChange extends Change {
+  async enact () {
+    const beforePath = this.tree.randomFile()
+    const afterPath = this.tree.newFileName()
+    this.tree.fileWasDeleted(beforePath)
+    await fs.rename(beforePath, afterPath)
+    return new RenameEventMatcher({
+      kind: 'file',
+      oldPath: beforePath,
+      newPath: afterPath
+    })
+  }
+}
+
+class DirectoryCreationChange extends Change {
+  async enact () {
+    const dirPath = await this.tree.createNewDirectory()
+    return new SingleEventMatcher({
+      action: 'created',
+      kind: 'directory',
+      path: dirPath
+    })
+  }
+}
+
+class DirectoryDeletionChange extends Change {
+  async enact () {
+    const dirPath = this.tree.randomEmptyDirectory()
+    this.tree.directoryWasDeleted(dirPath)
+    await fs.unlink(dirPath)
+    return new SingleEventMatcher({
+      action: 'deleted',
+      kind: 'directory',
+      path: dirPath
+    })
+  }
+}
+
+class DirectoryRenameChange extends Change {
+  async enact () {
+    const beforePath = this.tree.randomEmptyDirectory()
+    const afterPath = this.tree.newDirectoryName()
+    this.tree.directoryWasDeleted(beforePath)
+    await fs.rename(beforePath, afterPath)
+    return new RenameEventMatcher({
+      kind: 'directory',
+      oldPath: beforePath,
+      newPath: afterPath
+    })
+  }
+}
+
+module.exports = {
+  FileCreationChange,
+  FileModificationChange,
+  FileDeletionChange,
+  FileRenameChange,
+  DirectoryCreationChange,
+  DirectoryDeletionChange,
+  DirectoryRenameChange
+}

--- a/src/random-fs/changes.js
+++ b/src/random-fs/changes.js
@@ -37,7 +37,6 @@ class FileCreationChange extends Change {
 class FileModificationChange extends Change {
   async enact () {
     this.filePath = this.tree.randomFile()
-    console.log(this.toString())
     await fs.appendFile(this.filePath, 'appended a line\n')
     return new SingleEventMatcher({
       action: 'modified',
@@ -58,7 +57,6 @@ class FileModificationChange extends Change {
 class FileDeletionChange extends Change {
   async enact () {
     this.filePath = this.tree.randomFile()
-    console.log(this.toString())
     this.tree.fileWasDeleted(this.filePath)
     await fs.unlink(this.filePath)
     return new SingleEventMatcher({
@@ -81,7 +79,6 @@ class FileRenameChange extends Change {
   async enact () {
     this.beforePath = this.tree.randomFile()
     this.afterPath = this.tree.newFileName()
-    console.log(this.toString())
     this.tree.fileWasDeleted(this.beforePath)
     this.tree.fileWillBeAdded(this.afterPath)
     await fs.rename(this.beforePath, this.afterPath)
@@ -105,7 +102,6 @@ class FileRenameChange extends Change {
 class DirectoryCreationChange extends Change {
   async enact () {
     this.dirPath = this.tree.newDirectoryName()
-    console.log(this.toString())
     this.tree.directoryWillBeAdded(this.dirPath)
     await fs.mkdir(this.dirPath)
     this.tree.directoryWasAdded(this.dirPath)
@@ -128,7 +124,6 @@ class DirectoryCreationChange extends Change {
 class DirectoryDeletionChange extends Change {
   async enact () {
     this.dirPath = this.tree.randomEmptyDirectory()
-    console.log(this.toString())
     this.tree.directoryWasDeleted(this.dirPath)
     await fs.rmdir(this.dirPath)
     return new SingleEventMatcher({
@@ -151,7 +146,6 @@ class DirectoryRenameChange extends Change {
   async enact () {
     this.beforePath = this.tree.randomDirectory()
     this.afterPath = this.tree.newDirectoryName(this.beforePath)
-    console.log(this.toString())
     await this.tree.directoryWasRenamed(
       this.beforePath,
       () => fs.rename(this.beforePath, this.afterPath),

--- a/src/random-fs/churn.js
+++ b/src/random-fs/churn.js
@@ -1,0 +1,61 @@
+const {PromiseQueue} = require('../queue')
+const {chooseProportionally, reportError} = require('../helpers')
+
+const {Unmatched} = require('./unmatched')
+const changes = require('./changes')
+
+async function churn ({tree, subscribe, iterations, parallel, profile, report}) {
+  const unmatched = new Unmatched()
+  const queue = new PromiseQueue(parallel)
+
+  const changeChoices = Object.keys(profile).map(change => {
+    const ChangeConstructor = changes[change]
+    if (!ChangeConstructor) {
+      throw new Error(`Unrecognized change name: ${change}`)
+    }
+    return [profile[change].proportion, new ChangeConstructor(tree)]
+  })
+
+  subscribe(evt => {
+    const match = unmatched.observe(evt)
+    report.count(match)
+  })
+
+  const changePromises = []
+  let changeCount = 0
+  while (changeCount < iterations || queue.waitingCount() > 0) {
+    const viable = changeChoices.filter(choice => choice[1].isViable())
+    if (viable.length > 0) {
+      const change = chooseProportionally(viable)
+
+      changeCount++
+      changePromises.push(queue.enqueue(async () => {
+        if (!change.isViable()) {
+          process.stdout.write('-'.sidenote)
+          changeCount--
+          return
+        }
+
+        try {
+          const matcher = await change.enact()
+          unmatched.expect(matcher)
+          process.stdout.write('.')
+        } catch (e) {
+          process.stdout.write('X\n')
+          reportError(e)
+        }
+      }, change))
+    }
+
+    if (queue.waitingCount() > parallel) {
+      await queue.whenEmpty()
+      process.stdout.write('\n')
+    }
+  }
+
+  await Promise.all(changePromises)
+
+  return report
+}
+
+module.exports = {churn}

--- a/src/random-fs/churn.js
+++ b/src/random-fs/churn.js
@@ -1,4 +1,3 @@
-const {PromiseQueue} = require('../queue')
 const {chooseProportionally, reportError} = require('../helpers')
 
 const {Unmatched} = require('./unmatched')
@@ -25,8 +24,9 @@ async function churn ({tree, subscribe, iterations, profile, report}) {
     const change = chooseProportionally(viable)
 
     try {
-      const matcher = await change.enact()
-      unmatched.expect(matcher)
+      change.prepare()
+      unmatched.expect(change.matcher())
+      await change.enact()
       process.stdout.write('.')
     } catch (e) {
       process.stdout.write('\nX'.danger)

--- a/src/random-fs/churn.js
+++ b/src/random-fs/churn.js
@@ -1,5 +1,4 @@
 const {chooseProportionally, reportError} = require('../helpers')
-
 const {Unmatched} = require('./unmatched')
 const changes = require('./changes')
 

--- a/src/random-fs/churn.js
+++ b/src/random-fs/churn.js
@@ -37,6 +37,10 @@ async function churn ({tree, subscribe, iterations, profile, report}) {
     if (changeCount % 80 === 79) process.stdout.write('\n')
   }
 
+  for (const missed of unmatched.allMissed()) {
+    report.count(missed)
+  }
+
   return report
 }
 

--- a/src/random-fs/index.js
+++ b/src/random-fs/index.js
@@ -1,4 +1,6 @@
 const {Tree} = require('./tree')
+const {churn} = require('./churn')
+const {Report} = require('./report')
 
 exports.createTree = async function (options) {
   const t = new Tree(options)
@@ -7,3 +9,7 @@ exports.createTree = async function (options) {
   }
   return t
 }
+
+exports.churn = churn
+
+exports.Report = Report

--- a/src/random-fs/matcher.js
+++ b/src/random-fs/matcher.js
@@ -125,7 +125,7 @@ class RenameEventMatcher {
 
     for (const pair of this.pairMatchers) {
       if (!pair.match) {
-        pair.match = pair.matcher.match(evt)
+        pair.match = pair.matcher.matches(evt)
       }
 
       if (pair.match) {

--- a/src/random-fs/matcher.js
+++ b/src/random-fs/matcher.js
@@ -1,14 +1,17 @@
 const EXACT = {exact: true}
 const UNEXPECTED = {unexpected: true}
+const MISSED = {missed: true}
 
 class Match {
   static exact (latency, action) { return new Match(latency, action, EXACT) }
 
   static unknown (latency, action, count) { return new Match(latency, action, {unknown: count}) }
 
+  static split (latency, unknownCount) { return new Match(latency, 'rename', {split: true, unknown: unknownCount}) }
+
   static unexpected (action) { return new Match(0, action, UNEXPECTED) }
 
-  static split (latency, unknownCount) { return new Match(latency, 'rename', {split: true, unknown: unknownCount}) }
+  static missed (action) { return new Match(0, action, MISSED) }
 
   constructor (latency, action, opts) {
     this.latency = latency
@@ -40,6 +43,10 @@ class Match {
     return this.opts.unexpected === true
   }
 
+  isMissed () {
+    return this.opts.missed === true
+  }
+
   isSplitExact () {
     return this.opts.split && this.opts.unknownCount === 0
   }
@@ -50,6 +57,10 @@ class Match {
 
   isSplitFullUnknown () {
     return this.opts.split && this.opts.unknownCount === 2
+  }
+
+  measuredLatency () {
+    return !this.isUnexpected() && !this.isMissed()
   }
 }
 
@@ -84,6 +95,10 @@ class SingleEventMatcher {
     const ps = [this.path]
     if (this.oldPath) ps.push(this.oldPath)
     return ps
+  }
+
+  missed () {
+    return Match.missed(this.action)
   }
 }
 
@@ -146,6 +161,10 @@ class RenameEventMatcher {
 
   getPaths () {
     return this.renameMatcher.getPaths()
+  }
+
+  missed () {
+    return Match.missed('renamed')
   }
 }
 

--- a/src/random-fs/matcher.js
+++ b/src/random-fs/matcher.js
@@ -1,6 +1,4 @@
 const EXACT = {exact: true}
-const UNEXPECTED = {unexpected: true}
-const MISSED = {missed: true}
 
 class Match {
   static exact (latency, action) { return new Match(latency, action, EXACT) }
@@ -9,9 +7,9 @@ class Match {
 
   static split (latency, unknownCount) { return new Match(latency, 'rename', {split: true, unknown: unknownCount}) }
 
-  static unexpected (action) { return new Match(0, action, UNEXPECTED) }
+  static unexpected (action, evt) { return new Match(0, action, {unexpected: true, event: evt}) }
 
-  static missed (action) { return new Match(0, action, MISSED) }
+  static missed (action, evt) { return new Match(0, action, {missed: true, event: evt}) }
 
   constructor (latency, action, opts) {
     this.latency = latency
@@ -25,6 +23,10 @@ class Match {
 
   getLatency () {
     return this.latency
+  }
+
+  getEvent () {
+    return this.opts.event
   }
 
   when (callbacks) {
@@ -98,7 +100,9 @@ class SingleEventMatcher {
   }
 
   missed () {
-    return Match.missed(this.action)
+    const evt = {action: this.action, kind: this.kind, path: this.path}
+    if (this.oldPath) evt.oldPath = this.oldPath
+    return Match.missed(this.action, evt)
   }
 }
 
@@ -164,7 +168,7 @@ class RenameEventMatcher {
   }
 
   missed () {
-    return Match.missed('renamed')
+    return Match.missed('renamed', this.renameMatcher.missed().getEvent())
   }
 }
 

--- a/src/random-fs/matcher.js
+++ b/src/random-fs/matcher.js
@@ -1,0 +1,126 @@
+const EXACT = {exact: true}
+const UNEXPECTED = {unexpected: true}
+
+class Match {
+  static exact (action) { return new Match(action, EXACT) }
+
+  static unknown (action, count) { return new Match(action, {unknown: count}) }
+
+  static unexpected (action) { return new Match(action, UNEXPECTED) }
+
+  static split (unknownCount) { return new Match('rename', {split: true, unknown: unknownCount}) }
+
+  constructor (action, opts) {
+    this.action = action
+    this.opts = opts
+  }
+
+  getAction () {
+    return this.action
+  }
+
+  when (callbacks) {
+    callbacks[this.action](this)
+  }
+
+  isExact () {
+    return this.opts.exact === true
+  }
+
+  isUnknown () {
+    return !this.opts.split && (this.opts.unknown || 0) > 0
+  }
+
+  isUnexpected () {
+    return this.opts.unexpected === true
+  }
+
+  isSplitExact () {
+    return this.opts.split && this.opts.unknownCount === 0
+  }
+
+  isSplitHalfUnknown () {
+    return this.opts.split && this.opts.unknownCount === 1
+  }
+
+  isSplitFullUnknown () {
+    return this.opts.split && this.opts.unknownCount === 2
+  }
+}
+
+class SingleEventMatcher {
+  constructor (spec) {
+    this.action = spec.action
+    this.kind = spec.kind
+    this.path = spec.path
+    this.oldPath = spec.oldPath
+
+    this.creationTime = Date.now()
+    this.latencyMs = null
+  }
+
+  matches (evt) {
+    if (
+      this.action === evt.action &&
+      this.path === evt.path &&
+      (evt.kind === 'unknown' || this.kind === evt.kind) &&
+      (this.oldPath === null || this.oldPath === evt.oldPath)
+    ) {
+      this.latencyMs = Date.now() - this.creationTime
+
+      return evt.kind === 'unknown' ? match.SINGLE_UNKNOWN : match.SINGLE_EXACT
+    }
+
+    return null
+  }
+
+  hasMatched () {
+    return this.latencyMs !== null
+  }
+
+  getPaths () {
+    const ps = [this.path]
+    if (this.oldPath) ps.push(this.oldPath)
+    return ps
+  }
+}
+
+class RenameEventMatcher {
+  constructor (spec) {
+    this.renameMatcher = new SingleEventMatcher({
+      action: 'renamed',
+      kind: spec.kind,
+      path: spec.path,
+      oldPath: spec.oldPath
+    })
+
+    this.pairMatchers = [
+      new SingleEventMatcher({
+        action: 'deleted',
+        kind: spec.kind,
+        path: spec.oldPath
+      }),
+      new SingleEventMatcher({
+        action: 'created',
+        kind: spec.kind,
+        path: spec.path
+      })
+    ]
+  }
+
+  matches (evt) {
+    if (this.renameMatcher.matches(evt)) {
+      return match.RENAME_EXACT
+    } else if (this.pairMatchers.every(matcher => matcher.hasMatched() || matcher.match(evt))) {
+      return match.RENAME_SPLIT
+    } else {
+      return null
+    }
+  }
+
+  getPaths () {
+    return this.renameMatcher.getPaths()
+  }
+}
+
+module.exports = {SingleEventMatcher, RenameEventMatcher, Match}

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -56,7 +56,9 @@ class Report {
       console.log(`${name.header} total: ${t}`)
       for (const key of Object.keys(counters)) {
         const decamel = key.replace(/([a-z])([A-Z])/, (m, p1, p2) => p1 + ' ' + p2.toLowerCase())
-        const percent = Math.floor((counters[key] / t) * 10000) / 100
+        const percent = t !== 0
+          ? Math.floor((counters[key] / t) * 10000) / 100
+          : 0
 
         console.log(` - ${decamel}: ${counters[key]} ` + `(${percent}%)`.sidenote)
       }

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -54,7 +54,7 @@ class Report {
       renamed: () => increment(this.renamed)
     })
 
-    if (!match.isUnexpected()) {
+    if (match.measuredLatency()) {
       this.latencies.push(match.getLatency())
     }
   }

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -23,7 +23,8 @@ class Report {
       unknown: 0,
       splitExact: 0,
       splitHalfUnknown: 0,
-      splitFullUnknown: 0
+      splitFullUnknown: 0,
+      unexpected: 0
     }
   }
 

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -1,0 +1,72 @@
+class Report {
+  constructor () {
+    this.created = {
+      exact: 0,
+      unknown: 0,
+      unexpected: 0
+    }
+
+    this.modified = {
+      exact: 0,
+      unknown: 0,
+      unexpected: 0
+    }
+
+    this.deleted = {
+      exact: 0,
+      unknown: 0,
+      unexpected: 0
+    }
+
+    this.renamed = {
+      exact: 0,
+      unknown: 0,
+      splitExact: 0,
+      splitHalfUnknown: 0,
+      splitFullUnknown: 0
+    }
+  }
+
+  count (match) {
+    function increment (counters) {
+      if (match.isExact()) counters.exact++
+      if (match.isUnknown()) counters.unknown++
+      if (match.isUnexpected()) counters.unexpected++
+      if (match.isSplitExact()) counters.splitExact++
+      if (match.isSplitHalfUnknown()) counters.splitHalfUnknown++
+      if (match.isSplitFullUnknown()) counters.splitFullUnknown++
+    }
+
+    match.when({
+      created: () => increment(this.created),
+      modified: () => increment(this.modified),
+      deleted: () => increment(this.deleted),
+      renamed: () => increment(this.renamed)
+    })
+  }
+
+  summarize () {
+    function total (counters) {
+      return Object.keys(counters).reduce((sum, key) => sum + counters[key], 0)
+    }
+
+    function section (name, counters) {
+      const t = total(counters)
+
+      console.log(`${name.header} total: ${t}`)
+      for (const key of Object.keys(counters)) {
+        const decamel = key.replace(/([a-z])([A-Z])/, (m, p1, p2) => p1 + ' ' + p2.toLowerCase())
+        const percent = Math.floor((counters[key] / t) * 10000) / 100
+
+        console.log(` - ${decamel}: ${counters[key]} ` + `(${percent}%)`.sidenote)
+      }
+    }
+
+    console.log('>> ACCURACY <<'.banner)
+    for (const key of ['created', 'modified', 'deleted', 'renamed']) {
+      section(key, this[key])
+    }
+  }
+}
+
+module.exports = {Report}

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -5,19 +5,22 @@ class Report {
     this.created = {
       exact: 0,
       unknown: 0,
-      unexpected: 0
+      unexpected: 0,
+      missed: 0
     }
 
     this.modified = {
       exact: 0,
       unknown: 0,
-      unexpected: 0
+      unexpected: 0,
+      missed: 0
     }
 
     this.deleted = {
       exact: 0,
       unknown: 0,
-      unexpected: 0
+      unexpected: 0,
+      missed: 0
     }
 
     this.renamed = {
@@ -26,7 +29,8 @@ class Report {
       splitExact: 0,
       splitHalfUnknown: 0,
       splitFullUnknown: 0,
-      unexpected: 0
+      unexpected: 0,
+      missed: 0
     }
 
     this.latencies = []
@@ -37,6 +41,7 @@ class Report {
       if (match.isExact()) counters.exact++
       if (match.isUnknown()) counters.unknown++
       if (match.isUnexpected()) counters.unexpected++
+      if (match.isMissed()) counters.missed++
       if (match.isSplitExact()) counters.splitExact++
       if (match.isSplitHalfUnknown()) counters.splitHalfUnknown++
       if (match.isSplitFullUnknown()) counters.splitFullUnknown++

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -1,3 +1,5 @@
+const {humanMilliseconds} = require('../helpers')
+
 class Report {
   constructor () {
     this.created = {
@@ -26,6 +28,8 @@ class Report {
       splitFullUnknown: 0,
       unexpected: 0
     }
+
+    this.latencies = []
   }
 
   count (match) {
@@ -44,6 +48,10 @@ class Report {
       deleted: () => increment(this.deleted),
       renamed: () => increment(this.renamed)
     })
+
+    if (!match.isUnexpected()) {
+      this.latencies.push(match.getLatency())
+    }
   }
 
   summarize () {
@@ -69,6 +77,18 @@ class Report {
     for (const key of ['created', 'modified', 'deleted', 'renamed']) {
       section(key, this[key])
     }
+
+    const mean = this.latencies.reduce((sum, ms) => sum + ms) / this.latencies.length
+    this.latencies.sort()
+    const median = this.latencies[Math.ceil(this.latencies.length * 0.5)]
+    const percentile95 = this.latencies[Math.ceil(this.latencies.length * 0.95)]
+    const max = this.latencies[this.latencies.length - 1]
+
+    console.log('\n>> LATENCY <<'.banner)
+    console.log(` - mean: ${humanMilliseconds(mean)}`)
+    console.log(` - median: ${humanMilliseconds(median)}`)
+    console.log(` - 95%: ${humanMilliseconds(percentile95)}`)
+    console.log(` - maximum: ${humanMilliseconds(max)}`)
   }
 }
 

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -114,11 +114,12 @@ class Report {
       section(key, this[key])
     }
 
+    const lastLatencyInd = this.latencies.length - 1
     const mean = this.latencies.reduce((sum, ms) => sum + ms) / this.latencies.length
     this.latencies.sort()
-    const median = this.latencies[Math.ceil(this.latencies.length * 0.5)]
-    const percentile95 = this.latencies[Math.ceil(this.latencies.length * 0.95)]
-    const max = this.latencies[this.latencies.length - 1]
+    const median = this.latencies[Math.ceil(lastLatencyInd * 0.5)]
+    const percentile95 = this.latencies[Math.ceil(lastLatencyInd * 0.95)]
+    const max = this.latencies[lastLatencyInd]
 
     console.log('\n>> LATENCY <<'.banner)
     console.log(` - mean: ${humanMilliseconds(mean)}`)

--- a/src/random-fs/report.js
+++ b/src/random-fs/report.js
@@ -55,7 +55,7 @@ class Report {
 
       console.log(`${name.header} total: ${t}`)
       for (const key of Object.keys(counters)) {
-        const decamel = key.replace(/([a-z])([A-Z])/, (m, p1, p2) => p1 + ' ' + p2.toLowerCase())
+        const decamel = key.replace(/([a-z])([A-Z])/g, (m, p1, p2) => p1 + ' ' + p2.toLowerCase())
         const percent = t !== 0
           ? Math.floor((counters[key] / t) * 10000) / 100
           : 0

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs-extra')
 const {atRandom, tempDir} = require('../helpers')
+const {fileCreation: FileCreationChange, directoryCreation: DirectoryCreationChange} = require('./changes')
 
 class Tree {
   constructor (opts) {
@@ -79,10 +80,12 @@ class Tree {
 
     while (directoriesRemaining > 0 || filesRemaining > 0) {
       if (directoriesRemaining > 0 && Math.random() < this.directoryChance) {
-        await this.createNewDirectory()
+        const ch = new DirectoryCreationChange(this)
+        await ch.enact()
         directoriesRemaining--
       } else {
-        await this.createNewFile()
+        const ch = new FileCreationChange(this)
+        await ch.enact()
         filesRemaining--
       }
     }

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -129,6 +129,8 @@ class Tree {
     for (const d of emptyDirectoriesToAdd) this.emptyDirectories.add(d)
 
     this.directoryWasAdded(afterPath, beforeWasEmpty)
+
+    if (beforePath === this.root) this.root = afterPath
   }
 
   fileWasDeleted (filePath) {

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -22,8 +22,8 @@ class Tree {
     return name
   }
 
-  newDirectoryName () {
-    return path.join(this.randomDirectory(), this.namegen('directory-'))
+  newDirectoryName (notWithin = null) {
+    return path.join(this.randomDirectory(notWithin), this.namegen('directory-'))
   }
 
   newFileName () {
@@ -36,6 +36,21 @@ class Tree {
 
   randomDirectory () {
     return atRandom(Array.from(this.directories))
+  randomDirectory (notWithin = null) {
+    if (this.directories.size === 0) console.trace()
+    let potential = Array.from(this.directories)
+
+    if (notWithin) {
+      potential = potential.filter(dirPath => !dirPath.startsWith(dirPath))
+
+      if (potential.length === 0) {
+        return path.dirname(notWithin)
+      }
+    }
+
+    return atRandom(potential)
+  }
+
   }
 
   randomFile () {

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -136,11 +136,11 @@ class Tree {
   }
 
   async generate (opts) {
-    if (this.root) {
-      await fs.mkdirs(this.root)
-    } else {
-      this.root = await tempDir(this.prefix)
+    if (!this.root) {
+      const tmp = await tempDir(this.prefix)
+      this.root = path.join(tmp, 'root')
     }
+    await fs.mkdirs(this.root)
 
     this.directories.add(this.root)
 

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -161,6 +161,4 @@ class Tree {
   }
 }
 
-module.exports = {
-  Tree
-}
+module.exports = {Tree}

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -34,8 +34,18 @@ class Tree {
     return this.root
   }
 
-  randomDirectory () {
-    return atRandom(Array.from(this.directories))
+  hasFile () {
+    return this.files.size > 0
+  }
+
+  hasDirectory () {
+    return this.directories.size > 0
+  }
+
+  hasEmptyDirectory () {
+    return this.emptyDirectories.size > 0
+  }
+
   randomDirectory (notWithin = null) {
     if (this.directories.size === 0) console.trace()
     let potential = Array.from(this.directories)

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -102,18 +102,18 @@ class Tree {
     const emptyDirectoriesToAdd = new Set()
 
     for (const existingFile of this.files) {
-      if (existingFile.startsWith(beforePath)) {
+      if (existingFile.startsWith(beforePath + '/')) {
         this.files.delete(existingFile)
-        filesToAdd.add(existingFile.replace(beforePath, afterPath))
+        filesToAdd.add(existingFile.replace(beforePath + '/', afterPath + '/'))
       }
     }
 
     for (const existingDir of this.directories) {
-      if (existingDir.startsWith(beforePath)) {
+      if (existingDir.startsWith(beforePath + '/')) {
         this.directories.delete(existingDir)
         const wasEmpty = this.emptyDirectories.delete(existingDir)
 
-        const renamed = existingDir.replace(beforePath, afterPath)
+        const renamed = existingDir.replace(beforePath + '/', afterPath + '/')
 
         directoriesToAdd.add(renamed)
         if (wasEmpty) {

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -150,10 +150,12 @@ class Tree {
     while (directoriesRemaining > 0 || filesRemaining > 0) {
       if (directoriesRemaining > 0 && Math.random() < this.directoryChance) {
         const ch = new DirectoryCreationChange(this)
+        ch.prepare()
         await ch.enact()
         directoriesRemaining--
       } else {
         const ch = new FileCreationChange(this)
+        ch.prepare()
         await ch.enact()
         filesRemaining--
       }

--- a/src/random-fs/tree.js
+++ b/src/random-fs/tree.js
@@ -10,8 +10,9 @@ class Tree {
     this.id = 0
     this.root = opts.root
 
-    this.directories = []
-    this.files = []
+    this.directories = new Set()
+    this.emptyDirectories = new Set()
+    this.files = new Set()
   }
 
   namegen (prefix, suffix = '') {
@@ -20,30 +21,48 @@ class Tree {
     return name
   }
 
+  newDirectoryName () {
+    return path.join(this.randomDirectory(), this.namegen('directory-'))
+  }
+
+  newFileName () {
+    return path.join(this.randomDirectory(), this.namegen('file-', '.txt'))
+  }
+
   getRoot () {
     return this.root
   }
 
   randomDirectory () {
-    return atRandom(this.directories)
+    return atRandom(Array.from(this.directories))
   }
 
   randomFile () {
-    return atRandom(this.files)
+    return atRandom(Array.from(this.files))
   }
 
   async createNewDirectory () {
-    const name = path.join(this.randomDirectory(), this.namegen('directory-'))
+    const name = this.newDirectoryName()
     await fs.mkdir(name, 0o777)
-    this.directories.push(name)
+    this.directories.add(name)
+    this.emptyDirectories.add(name)
     return name
   }
 
   async createNewFile () {
-    const name = path.join(this.randomDirectory(), this.namegen('file-', '.txt'))
+    const name = this.newFileName()
+    this.emptyDirectories.delete(path.dirname(name))
     await fs.writeFile(name, '\n', {encoding: 'utf8'})
-    this.files.push(name)
+    this.files.add(name)
     return name
+  }
+
+  directoryWasDeleted (dirPath) {
+    return this.directories.delete(dirPath)
+  }
+
+  fileWasDeleted (filePath) {
+    return this.files.delete(filePath)
   }
 
   async generate (opts) {

--- a/src/random-fs/unmatched.js
+++ b/src/random-fs/unmatched.js
@@ -1,0 +1,65 @@
+const {Match} = require('./matcher')
+
+class Unmatched {
+  constructor () {
+    this.head = null
+    this.tail = null
+
+    this.byPath = new Map()
+  }
+
+  expect (matcher) {
+    const node = {matcher, prev: null, next: null}
+
+    if (!this.head) {
+      this.head = node
+      this.tail = node
+    } else {
+      this.tail.next = node
+      node.prev = this.tail
+
+      this.tail = node
+    }
+
+    for (const p of matcher.getPaths()) {
+      let ms = this.byPath.get(p)
+      if (!ms) {
+        ms = new Set()
+        this.byPath.set(p, ms)
+      }
+      ms.add(node)
+    }
+  }
+
+  observe (evt) {
+    const potential = new Set()
+    for (const p of [evt.path, evt.oldPath]) {
+      if (!p) continue
+      for (const node of this.byPath.get(p) || []) {
+        potential.add(node)
+      }
+    }
+
+    for (const node of potential) {
+      const m = node.matcher.matches(evt)
+      if (m) {
+        // Remove this node
+        if (node.prev) node.prev.next = node.next
+        if (node.next) node.next.prev = node.prev
+        if (this.tail === node) this.tail = node.prev
+        if (this.head === node) this.head = node.next
+
+        for (const p of node.matcher.getPaths()) {
+          const ms = this.byPath.get(p)
+          if (ms) ms.delete(node)
+        }
+
+        return m
+      }
+    }
+
+    return Match.unexpected(evt.action)
+  }
+}
+
+module.exports = {Unmatched}

--- a/src/random-fs/unmatched.js
+++ b/src/random-fs/unmatched.js
@@ -2,32 +2,17 @@ const {Match} = require('./matcher')
 
 class Unmatched {
   constructor () {
-    this.head = null
-    this.tail = null
-
     this.byPath = new Map()
   }
 
   expect (matcher) {
-    const node = {matcher, prev: null, next: null}
-
-    if (!this.head) {
-      this.head = node
-      this.tail = node
-    } else {
-      this.tail.next = node
-      node.prev = this.tail
-
-      this.tail = node
-    }
-
     for (const p of matcher.getPaths()) {
       let ms = this.byPath.get(p)
       if (!ms) {
         ms = new Set()
         this.byPath.set(p, ms)
       }
-      ms.add(node)
+      ms.add(matcher)
     }
   }
 
@@ -35,23 +20,18 @@ class Unmatched {
     const potential = new Set()
     for (const p of [evt.path, evt.oldPath]) {
       if (!p) continue
-      for (const node of this.byPath.get(p) || []) {
-        potential.add(node)
+      for (const matcher of this.byPath.get(p) || []) {
+        potential.add(matcher)
       }
     }
 
-    for (const node of potential) {
-      const m = node.matcher.matches(evt)
+    for (const matcher of potential) {
+      const m = matcher.matches(evt)
       if (m) {
         // Remove this node
-        if (node.prev) node.prev.next = node.next
-        if (node.next) node.next.prev = node.prev
-        if (this.tail === node) this.tail = node.prev
-        if (this.head === node) this.head = node.next
-
-        for (const p of node.matcher.getPaths()) {
+        for (const p of matcher.getPaths()) {
           const ms = this.byPath.get(p)
-          if (ms) ms.delete(node)
+          if (ms) ms.delete(matcher)
         }
 
         return m

--- a/src/random-fs/unmatched.js
+++ b/src/random-fs/unmatched.js
@@ -40,6 +40,10 @@ class Unmatched {
 
     return Match.unexpected(evt.action)
   }
+
+  allMissed () {
+    return Array.from(this.byPath, ([, matcher]) => matcher.missed())
+  }
 }
 
 module.exports = {Unmatched}

--- a/src/random-fs/unmatched.js
+++ b/src/random-fs/unmatched.js
@@ -38,7 +38,7 @@ class Unmatched {
       }
     }
 
-    return Match.unexpected(evt.action)
+    return Match.unexpected(evt.action, evt)
   }
 
   allMissed () {

--- a/src/random-fs/unmatched.js
+++ b/src/random-fs/unmatched.js
@@ -42,7 +42,13 @@ class Unmatched {
   }
 
   allMissed () {
-    return Array.from(this.byPath, ([, matcher]) => matcher.missed())
+    const missed = []
+    for (const [, matchers] of this.byPath) {
+      for (const matcher of matchers) {
+        missed.push(matcher.missed())
+      }
+    }
+    return missed
   }
 }
 

--- a/src/serial-watchers.js
+++ b/src/serial-watchers.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const {reportUsage, reportError} = require('./helpers')
 const {createTree, churn, Report} = require('./random-fs')
 
@@ -41,13 +42,14 @@ async function runWatcher (facade, i, opts, tree, report) {
     }
   )
 
-  console.log('creating 1000 filesystem events\n')
+  console.log(`creating ${opts.churnCount} filesystem events\n`)
   await churn({
     tree,
     subscribe: cb => { receive = cb },
     iterations: opts.churnCount,
     profile: opts.churnProfile,
-    report
+    report,
+    logPath: path.join(opts.loggingDir, 'changes.log')
   })
 
   await watcher.stop()

--- a/src/serial-watchers.js
+++ b/src/serial-watchers.js
@@ -1,8 +1,7 @@
-const fs = require('fs-extra')
-const path = require('path')
+const {reportUsage, reportError} = require('./helpers')
+const {createTree, churn, Report} = require('./random-fs')
 
-const {atRandom, reportUsage, reportError} = require('./helpers')
-const {createTree} = require('./random-fs')
+const defaultChurnProfile = require('./default-churn-profile')
 
 module.exports = async function (facade, opts) {
   console.log('>> SERIAL WATCHER STRESS TEST <<'.banner)
@@ -14,49 +13,45 @@ module.exports = async function (facade, opts) {
     fileCount: 10000
   })
 
+  const report = new Report({
+    loggingDir: opts.loggingDir
+  })
+
   for (let i = 0; i < opts.count; i++) {
-    await runWatcher(facade, i, opts, tree.randomDirectory())
+    await runWatcher(facade, i, opts, tree, report)
   }
 
+  console.log('\n')
+  report.summarize()
   await reportUsage()
 }
 
-async function runWatcher (facade, i, opts, directory) {
-  console.log(`starting watcher #${i}`.header + ` on ${path.basename(directory)}`.sidenote)
+async function runWatcher (facade, i, opts, tree, report) {
+  console.log(`starting watcher #${i}`.header)
 
-  let eventCount = 0
+  let receive = () => {}
 
   const watcher = await facade.start(
-    directory,
+    tree.getRoot(),
     {poll: opts.poll},
     (err, events) => {
       if (err) {
         reportError(err)
         return
       }
-      eventCount += events.length
+      events.forEach(receive)
     }
   )
 
-  const entries = await fs.readdir(directory)
-  const files = (await Promise.all(
-    entries.map(async entry => {
-      const fullPath = path.join(directory, entry)
-      const stat = await fs.stat(fullPath)
-      return stat.isFile() ? fullPath : null
-    })
-  )).filter(entry => entry !== null)
-
-  if (files.length > 0) {
-    for (let i = 0; i < 10; i++) {
-      await fs.appendFile(atRandom(files), `wat wat ${i}\n`, {encoding: 'utf8'})
-    }
-
-    await new Promise(resolve => setTimeout(resolve, 100))
-  }
-
-  console.log(`watcher on ${path.basename(directory)} captured ${eventCount} events`)
+  console.log('creating 1000 filesystem events\n')
+  await churn({
+    tree,
+    subscribe: cb => { receive = cb },
+    iterations: 1000,
+    profile: defaultChurnProfile,
+    report
+  })
 
   await watcher.stop()
-  console.log(`watcher #${i} stopped`)
+  console.log(`\n\nwatcher #${i} stopped`)
 }

--- a/src/serial-watchers.js
+++ b/src/serial-watchers.js
@@ -1,8 +1,6 @@
 const {reportUsage, reportError} = require('./helpers')
 const {createTree, churn, Report} = require('./random-fs')
 
-const defaultChurnProfile = require('./default-churn-profile')
-
 module.exports = async function (facade, opts) {
   console.log('>> SERIAL WATCHER STRESS TEST <<'.banner)
 
@@ -47,8 +45,8 @@ async function runWatcher (facade, i, opts, tree, report) {
   await churn({
     tree,
     subscribe: cb => { receive = cb },
-    iterations: 1000,
-    profile: defaultChurnProfile,
+    iterations: opts.churnCount,
+    profile: opts.churnProfile,
     report
   })
 


### PR DESCRIPTION
Perform randomized (with a seed!) permutations of a generated filesystem tree. Track the events we expect to see and measure the watcher's accuracy, accounting for events that are delivered with `kind: "unknown"` and renames that are split into creation and deletions. Measure the latency of each expected event and summarize the mean, 95-percentile, and max latencies of events overall, among non-renames, and among renames.

- [x] Report mean, median, 95-percentile, and max of event latencies
- [x] Count and report missed events
- [x] Log unexpected and missed events so that we can actually figure out what happened
- [x] Track down rejected promises with parallel churning
- [x] Churn during serial exercise
- [x] Add options to configure the event churn: event count and path to a churn profile