### PR TITLE
--exercise churn

### DIFF
--- a/src/churn.js
+++ b/src/churn.js
@@ -1,0 +1,51 @@
+const path = require('path')
+const {reportError} = require('./helpers')
+const {createTree, churn, Report} = require('./random-fs')
+
+module.exports = async function (facade, opts) {
+  console.log('>> CHURN TEST <<'.banner)
+
+  let eventCallback = () => {}
+
+  console.log('generating initial tree'.sidenote)
+  const tree = await createTree({
+    root: opts.root,
+    prefix: 'churn-',
+    directoryCount: opts.dirCount,
+    fileCount: opts.fileCount
+  })
+  console.log(`tree generated at ${tree.getRoot()}`.sidenote)
+
+  console.log('starting watcher'.sidenote)
+  const w = await facade.start(
+    tree.getRoot(),
+    {},
+    (err, events) => {
+      if (err) {
+        reportError(err)
+        return
+      }
+
+      events.forEach(eventCallback)
+    }
+  )
+  console.log(`\n>> PRODUCING ${opts.churnCount} FILESYSTEM EVENTS <<`.banner)
+
+  const report = new Report({loggingDir: opts.loggingDir})
+  const changeLog = opts.loggingDir ? path.join(opts.loggingDir, 'changes.log') : null
+  await churn({
+    tree,
+    subscribe: cb => { eventCallback = cb },
+    iterations: opts.churnCount,
+    profile: opts.churnProfile,
+    report,
+    logPath: changeLog
+  })
+
+  console.log(`\n>> STOPPING WATCHER <<`.banner)
+
+  await w.stop()
+
+  console.log('\n')
+  report.summarize()
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const cli = require('./cli')
 const {createFacade, available} = require('./facade')
 const serialWatchers = require('./serial-watchers')
 const parallelWatchers = require('./parallel-watchers')
+const churn = require('./churn')
 const gen = require('./gen')
 const {setResourceLogFile, reportError} = require('./helpers')
 
@@ -38,7 +39,7 @@ program
   .option('-i, --interval <ms>', 'interval to publish resource usage statistics', parseInt)
   .option('-r, --resource-log <path>', 'log resource usage to a JSON file')
   .option('-c, --cli <paths,>', 'CLI mode', str => str.split(','))
-  .option('-e, --exercise <exercise>', 'choose an exercise to perform (serial, parallel)', /^(serial|parallel)$/)
+  .option('-e, --exercise <exercise>', 'choose an exercise to perform (serial, parallel, churn)', /^(serial|parallel|churn)$/)
   .option('-r, --root <path>', 'specify a root path for exercises')
   .option('-g, --gen [path]', 'generate a random filesystem structure beneath a path')
   .option('--watcher-count <count>', 'configure the number of watchers for an exercise (default: 1000)', parseInt)
@@ -137,6 +138,16 @@ async function main () {
         loggingDir: program.loggingDir,
         churnCount: program.churnCount,
         churnProfile
+      })
+    } else if (program.exercise === 'churn') {
+      await churn(facade, {
+        root: program.root,
+        poll: program.poll,
+        loggingDir: program.loggingDir,
+        churnCount: program.churnCount,
+        churnProfile,
+        dirCount: program.dirCount || 10,
+        fileCount: program.fileCount || 200
       })
     }
 


### PR DESCRIPTION
Implement `--exercise churn`. It behaves like `--exercise parallel --watcher-count 1`, but is slightly easier to type.